### PR TITLE
fixed sign in message override

### DIFF
--- a/profiles/templates/profiles/profile.html
+++ b/profiles/templates/profiles/profile.html
@@ -12,6 +12,10 @@
     <div class="alert alert-danger" role="alert">
       {{message}}
     </div>
+  {% else %} 
+    <div class="alert alert-danger" role="alert">
+      {{message}}
+    </div>
     {% endif %}
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
Earlier the if statement in the html specified that only error messages could be outputted; changed the logic so it prioritizes error messages but does still output other messages 